### PR TITLE
Remove default email from `buildJwt`, add `buildUserJwt` with default email

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerx/graphql-apollo-server",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": false,
   "description": "A set of MakerX plugins for Apollo Server",
   "author": "MakerX",

--- a/src/testing/jwt.ts
+++ b/src/testing/jwt.ts
@@ -11,11 +11,15 @@ export interface BuildJwtInput {
   [key: string]: any
 }
 
+/**
+ *
+ * @param Optional JWT input
+ * @returns A JWT payload with oid, tid and sub claims set to random values if not provided
+ */
 export function buildJwt({
   oid = randomUUID(),
   tid = randomUUID(),
   sub = randomUUID(),
-  email = randomEmail(),
   scopes = [],
   roles = [],
   ...rest
@@ -24,13 +28,24 @@ export function buildJwt({
     oid,
     tid,
     sub,
-    email,
     scp: scopes.join(' '),
     roles,
     ...rest,
   }
 }
 
+/**
+ *
+ * @param Optional JWT input
+ * @returns A JWT payload with oid, tid, sub and email claims set to random values if not provided
+ */
+export function buildUserJwt({ email = randomEmail(), ...rest }: Partial<BuildJwtInput> = {}): JwtPayload {
+  return buildJwt({
+    email,
+    ...rest,
+  })
+}
+
 export function randomEmail() {
-  return `${(Math.random() + 1).toString(36).substring(7)}@test.net`
+  return `${(Math.random() + 1).toString(36).substring(2)}@test.net`
 }

--- a/src/testing/tests/me-query.test.ts
+++ b/src/testing/tests/me-query.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from 'vitest'
-import { buildJwt } from '../jwt'
+import { buildJwt, buildUserJwt } from '../jwt'
 import { graphql } from './gql'
 import { test } from './test-context'
 
@@ -15,9 +15,10 @@ const meQuery = graphql(`
 `)
 
 const jwtPayloads = {
-  basicUser: buildJwt(),
-  userWithRoles: buildJwt({ roles: ['Admin', 'Supervisor'] }),
-  userWithName: buildJwt({ name: 'Magda' }),
+  app: buildJwt(),
+  user: buildUserJwt(),
+  userWithRoles: buildUserJwt({ roles: ['Admin', 'Supervisor'] }),
+  userWithName: buildUserJwt({ name: 'Magda' }),
 }
 
 describe('me query operation', () => {
@@ -26,11 +27,18 @@ describe('me query operation', () => {
     expect(result.data?.me).toBeNull()
   })
 
-  test('returns basic user', async ({ executeOperation }) => {
-    const result = await executeOperation({ query: meQuery }, jwtPayloads.basicUser)
+  test('returns basic app (no email)', async ({ executeOperation }) => {
+    const result = await executeOperation({ query: meQuery }, jwtPayloads.app)
     expect(result.data?.me).toMatchObject({
-      id: jwtPayloads.basicUser.oid,
-      email: jwtPayloads.basicUser.email,
+      id: jwtPayloads.app.oid,
+    })
+  })
+
+  test('returns basic user (with email)', async ({ executeOperation }) => {
+    const result = await executeOperation({ query: meQuery }, jwtPayloads.user)
+    expect(result.data?.me).toMatchObject({
+      id: jwtPayloads.user.oid,
+      email: jwtPayloads.user.email,
     })
   })
 


### PR DESCRIPTION
# What ?

When consuming this library, I realised I needed to be able to easily create a test JWT payload **without** an email claim set.

For example, a JWT payload representing an application will likely not have an email set.

This PR removes the default email from the `buildJwt` testing function and adds a `buildUserJwt` which sets a default email for the payload.