### PR TITLE
Adds resolve custom logger to graphqlOperationLoggingPlugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerx/graphql-apollo-server",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "private": false,
   "description": "A set of MakerX plugins for Apollo Server",
   "author": "MakerX",

--- a/src/plugins/graphql-operation-logging-plugin.ts
+++ b/src/plugins/graphql-operation-logging-plugin.ts
@@ -85,10 +85,10 @@ export function graphqlOperationLoggingPlugin<TContext extends GraphQLContext<TL
         ctx: GraphQLRequestContextWillSendResponse<TContext>,
         subsequentPayload?: GraphQLExperimentalFormattedSubsequentIncrementalExecutionResult,
       ) {
-        const { started, logger } = {
-          ...contextValue,
-          ...(resolveCustomLogger ? { logger: resolveCustomLogger(contextValue) } : {}),
-        }
+        const { started } = contextValue
+        const { logger } = resolveCustomLogger
+          ? { logger: resolveCustomLogger(contextValue) }
+          : contextValue
         const { operationName, query, variables } = ctx.request
         const isIntrospection = query && isIntrospectionQuery(query)
         if (isIntrospection && ignoreIntrospectionQueries) return

--- a/src/plugins/graphql-operation-logging-plugin.ts
+++ b/src/plugins/graphql-operation-logging-plugin.ts
@@ -51,6 +51,10 @@ export interface GraphQLOperationLoggingPluginOptions<TContext extends GraphQLCo
    * Can be used to augment the log entry with additional properties
    */
   augmentLogEntry?: (ctx: TContext) => Record<string, any>
+  /**
+   * Can be used to resolve a custom logger for the plugin
+   */
+  resolveCustomLogger?: (context: TContext) => TLogger
 }
 
 /**
@@ -68,6 +72,7 @@ export function graphqlOperationLoggingPlugin<TContext extends GraphQLContext<TL
   adjustVariables,
   adjustResultData,
   augmentLogEntry,
+  resolveCustomLogger,
 }: GraphQLOperationLoggingPluginOptions<TContext, TLogger> = {}): ApolloServerPlugin<TContext> {
   return {
     contextCreationDidFail: async ({ error }) => {
@@ -80,7 +85,10 @@ export function graphqlOperationLoggingPlugin<TContext extends GraphQLContext<TL
         ctx: GraphQLRequestContextWillSendResponse<TContext>,
         subsequentPayload?: GraphQLExperimentalFormattedSubsequentIncrementalExecutionResult,
       ) {
-        const { started, logger } = contextValue
+        const { started, logger } = {
+          ...contextValue,
+          ...(resolveCustomLogger ? { logger: resolveCustomLogger(contextValue) } : {}),
+        }
         const { operationName, query, variables } = ctx.request
         const isIntrospection = query && isIntrospectionQuery(query)
         if (isIntrospection && ignoreIntrospectionQueries) return


### PR DESCRIPTION
This pull request adds support for resolving a custom logger in the `graphqlOperationLoggingPlugin`. The main change is the introduction of the `resolveCustomLogger` option, allowing users to specify a function to dynamically resolve the logger instance based on the plugin context.