### PR TITLE
Update arethetypeswrong

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@apollo/server": "^5.5.1",
-        "@arethetypeswrong/cli": "^0.18.2",
+        "@arethetypeswrong/cli": "^0.18.3",
         "@eslint/eslintrc": "3.3.5",
         "@eslint/js": "9.39.4",
         "@graphql-codegen/cli": "^6.3.1",
@@ -331,13 +331,13 @@
       }
     },
     "node_modules/@arethetypeswrong/cli": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.18.2.tgz",
-      "integrity": "sha512-PcFM20JNlevEDKBg4Re29Rtv2xvjvQZzg7ENnrWFSS0PHgdP2njibVFw+dRUhNkPgNfac9iUqO0ohAXqQL4hbw==",
+      "version": "0.18.3",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.18.3.tgz",
+      "integrity": "sha512-GeAlc+lUD4gKHD/LDQNvQY30FfQ+xAXg2inbQKUjFZgTOdI5ygEweaOnGHGBPSKXSLGQC7VLhpXu9zMnYk/4sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@arethetypeswrong/core": "0.18.2",
+        "@arethetypeswrong/core": "0.18.3",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.3",
         "commander": "^10.0.1",
@@ -353,16 +353,16 @@
       }
     },
     "node_modules/@arethetypeswrong/core": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.2.tgz",
-      "integrity": "sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==",
+      "version": "0.18.3",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.3.tgz",
+      "integrity": "sha512-sWBB/tdIktaT5xMq0Dz6CJyqcf6oMNdmiKiuPU1lWoJLTL6gjRSsksBuSgqot21hylkklBQY1wiSu+PkZhW7sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@andrewbranch/untar.js": "^1.0.3",
         "@loaderkit/resolve": "^1.0.2",
         "cjs-module-lexer": "^1.2.3",
-        "fflate": "^0.8.2",
+        "fflate": "^0.8.3",
         "lru-cache": "^11.0.1",
         "semver": "^7.5.4",
         "typescript": "5.6.1-rc",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@apollo/server": "^5.5.1",
-    "@arethetypeswrong/cli": "^0.18.2",
+    "@arethetypeswrong/cli": "^0.18.3",
     "@eslint/eslintrc": "3.3.5",
     "@eslint/js": "9.39.4",
     "@graphql-codegen/cli": "^6.3.1",


### PR DESCRIPTION
## Why

Release failed: <https://github.com/MakerXStudio/graphql-apollo-server/actions/runs/26752138573/job/78842640822>.

```
> @makerx/graphql-apollo-server@2.1.0 build:6-check-exports
> attw --pack dist
error while checking file:
Cannot read properties of undefined (reading 'filename')
ERROR: "build:6-check-exports" exited with 3.
Error: Process completed with exit code 1.
```

Linked to <https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues/258>.

## Tests

I ran `npm run build` locally and attw worked:

```
> @makerx/graphql-apollo-server@2.1.0 build:6-check-exports
> attw --pack dist


@makerx/graphql-apollo-server v2.1.0

 No problems found 🌟


┌───────────────────┬─────────────────────────────────┬─────────────────────────────────────────┐
│                   │ "@makerx/graphql-apollo-server" │ "@makerx/graphql-apollo-server/testing" │
├───────────────────┼─────────────────────────────────┼─────────────────────────────────────────┤
│ node10            │ 🟢                              │ 🟢                                      │
├───────────────────┼─────────────────────────────────┼─────────────────────────────────────────┤
│ node16 (from CJS) │ 🟢 (CJS)                        │ 🟢 (CJS)                                │
├───────────────────┼─────────────────────────────────┼─────────────────────────────────────────┤
│ node16 (from ESM) │ 🟢 (ESM)                        │ 🟢 (ESM)                                │
├───────────────────┼─────────────────────────────────┼─────────────────────────────────────────┤
│ bundler           │ 🟢                              │ 🟢                                      │
└───────────────────┴─────────────────────────────────┴─────────────────────────────────────────┘
```